### PR TITLE
Separate cheats and more

### DIFF
--- a/src/main/java/me/flashyreese/mods/sodiumextra/client/gui/SodiumExtraGameOptionPages.java
+++ b/src/main/java/me/flashyreese/mods/sodiumextra/client/gui/SodiumExtraGameOptionPages.java
@@ -259,7 +259,7 @@ public class SodiumExtraGameOptionPages {
                             .setName("Daylight Cycle")
                             .setTooltip("Shows the sun/moon and light according to the game time")
                             .setControl(TickBoxControl::new)
-                            .setBinding((options, value) -> options.extraSettings.dayTime = value, options -> options.extraSettings.dayTime)
+                            .setBinding((options, value) -> options.extraSettings.dayLightCycle = value, options -> options.extraSettings.dayLightCycle)
                             .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
                             .build()
                     )

--- a/src/main/java/me/flashyreese/mods/sodiumextra/client/gui/SodiumExtraGameOptionPages.java
+++ b/src/main/java/me/flashyreese/mods/sodiumextra/client/gui/SodiumExtraGameOptionPages.java
@@ -1,6 +1,7 @@
 package me.flashyreese.mods.sodiumextra.client.gui;
 
 import com.google.common.collect.ImmutableList;
+import me.flashyreese.mods.sodiumextra.client.SodiumExtraClientMod;
 import me.flashyreese.mods.sodiumextra.client.gui.options.storage.SodiumExtraOptionsStorage;
 import me.jellysquid.mods.sodium.client.gui.options.OptionFlag;
 import me.jellysquid.mods.sodium.client.gui.options.OptionGroup;
@@ -189,24 +190,16 @@ public class SodiumExtraGameOptionPages {
         groups.add(OptionGroup.createBuilder()
                 .add(OptionImpl.createBuilder(boolean.class, sodiumExtraOpts)
                         .setName("Show FPS")
-                        .setTooltip("")
+                        .setTooltip("Show current, max, average and min FPS on top left corner")
                         .setControl(TickBoxControl::new)
                         .setBinding((opts, value) -> opts.extraSettings.showFps = value, opts -> opts.extraSettings.showFps)
                         .build()
                 )
                 .add(OptionImpl.createBuilder(boolean.class, sodiumExtraOpts)
                         .setName("Fog")
-                        .setTooltip("")
+                        .setTooltip("Toggle all types of fog")
                         .setControl(TickBoxControl::new)
                         .setBinding((opts, value) -> opts.extraSettings.enableFog = value, opts -> opts.extraSettings.enableFog)
-                        .build()
-                )
-                .add(OptionImpl.createBuilder(boolean.class, sodiumExtraOpts)
-                        .setName("Show time")
-                        .setTooltip("Show the current daytime by the sun")
-                        .setControl(TickBoxControl::new)
-                        .setBinding((options, value) -> options.extraSettings.dayTime = value, options -> options.extraSettings.dayTime)
-                        .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
                         .build()
                 )
                 .add(OptionImpl.createBuilder(boolean.class, sodiumExtraOpts)
@@ -245,22 +238,42 @@ public class SodiumExtraGameOptionPages {
                         .build()
                 )
                 .add(OptionImpl.createBuilder(boolean.class, sodiumExtraOpts)
-                        .setName("No Overlays")
-                        .setTooltip("Disable camera overlays")
-                        .setControl(TickBoxControl::new)
-                        .setBinding((options, value) -> options.extraSettings.noOverlay = value, options -> options.extraSettings.noOverlay)
-                        .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
-                        .build()
-                )
-                .add(OptionImpl.createBuilder(boolean.class, sodiumExtraOpts)
                         .setName("Prevent Shaders")
                         .setTooltip("Prevents any types of shaders from loading")
                         .setControl(TickBoxControl::new)
                         .setBinding((options, value) -> options.extraSettings.preventShaders = value, options -> options.extraSettings.preventShaders)
                         .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
                         .build()
-                )
-                .build());
+                ).build());
+
+        if(!SodiumExtraClientMod.options().extraSettings.hideCheats){
+            groups.add(OptionGroup.createBuilder()
+                    .add(OptionImpl.createBuilder(boolean.class, sodiumExtraOpts)
+                            .setName("High Max Brightness")
+                            .setTooltip("Allow max brightness to go up to 1000 (reopen video settings to take effect)")
+                            .setControl(TickBoxControl::new)
+                            .setBinding((options, value) -> options.extraSettings.highMaxBrightness = value, options -> options.extraSettings.highMaxBrightness)
+                            .build()
+                    )
+                    .add(OptionImpl.createBuilder(boolean.class, sodiumExtraOpts)
+                            .setName("Daylight Cycle")
+                            .setTooltip("Shows the sun/moon and light according to the game time")
+                            .setControl(TickBoxControl::new)
+                            .setBinding((options, value) -> options.extraSettings.dayTime = value, options -> options.extraSettings.dayTime)
+                            .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
+                            .build()
+                    )
+                    .add(OptionImpl.createBuilder(boolean.class, sodiumExtraOpts)
+                            .setName("No Overlays")
+                            .setTooltip("Disable camera overlays")
+                            .setControl(TickBoxControl::new)
+                            .setBinding((options, value) -> options.extraSettings.noOverlay = value, options -> options.extraSettings.noOverlay)
+                            .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
+                            .build()
+                    )
+                    .build());
+        }
+
         return new OptionPage("Extras", ImmutableList.copyOf(groups));
     }
 }

--- a/src/main/java/me/flashyreese/mods/sodiumextra/client/gui/SodiumExtraGameOptions.java
+++ b/src/main/java/me/flashyreese/mods/sodiumextra/client/gui/SodiumExtraGameOptions.java
@@ -129,7 +129,7 @@ public class SodiumExtraGameOptions {
         public boolean lightUpdates;
         public boolean hideCheats;
         public boolean highMaxBrightness;
-        public boolean dayTime;
+        public boolean dayLightCycle;
         public boolean noOverlay;
 
         public ExtraSettings() {
@@ -143,7 +143,7 @@ public class SodiumExtraGameOptions {
             this.preventShaders = false;
             this.hideCheats = true;
             this.highMaxBrightness = false;
-            this.dayTime = true;
+            this.dayLightCycle = true;
             this.noOverlay = false;
         }
     }

--- a/src/main/java/me/flashyreese/mods/sodiumextra/client/gui/SodiumExtraGameOptions.java
+++ b/src/main/java/me/flashyreese/mods/sodiumextra/client/gui/SodiumExtraGameOptions.java
@@ -125,12 +125,12 @@ public class SodiumExtraGameOptions {
         public boolean toasts;
         public boolean staticFov;
         public boolean instantSneak;
-        public boolean noOverlay;
         public boolean preventShaders;
-        public boolean dayTime;
         public boolean lightUpdates;
-        public boolean highMaxBrightness;
         public boolean hideCheats;
+        public boolean highMaxBrightness;
+        public boolean dayTime;
+        public boolean noOverlay;
 
         public ExtraSettings() {
             this.showFps = true;

--- a/src/main/java/me/flashyreese/mods/sodiumextra/client/gui/SodiumExtraGameOptions.java
+++ b/src/main/java/me/flashyreese/mods/sodiumextra/client/gui/SodiumExtraGameOptions.java
@@ -141,7 +141,7 @@ public class SodiumExtraGameOptions {
             this.instantSneak = false;
             this.lightUpdates = true;
             this.preventShaders = false;
-            this.hideCheats = false;
+            this.hideCheats = true;
             this.highMaxBrightness = false;
             this.dayTime = true;
             this.noOverlay = false;

--- a/src/main/java/me/flashyreese/mods/sodiumextra/client/gui/SodiumExtraGameOptions.java
+++ b/src/main/java/me/flashyreese/mods/sodiumextra/client/gui/SodiumExtraGameOptions.java
@@ -129,6 +129,8 @@ public class SodiumExtraGameOptions {
         public boolean preventShaders;
         public boolean dayTime;
         public boolean lightUpdates;
+        public boolean highMaxBrightness;
+        public boolean hideCheats;
 
         public ExtraSettings() {
             this.showFps = true;
@@ -137,10 +139,12 @@ public class SodiumExtraGameOptions {
             this.toasts = true;
             this.staticFov = false;
             this.instantSneak = false;
-            this.noOverlay = false;
-            this.preventShaders = false;
-            this.dayTime = true;
             this.lightUpdates = true;
+            this.preventShaders = false;
+            this.hideCheats = false;
+            this.highMaxBrightness = false;
+            this.dayTime = true;
+            this.noOverlay = false;
         }
     }
 

--- a/src/main/java/me/flashyreese/mods/sodiumextra/mixin/features/day_time/MixinWorld.java
+++ b/src/main/java/me/flashyreese/mods/sodiumextra/mixin/features/day_time/MixinWorld.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.Mixin;
 public abstract class MixinWorld implements WorldAccess {
     @Override
     public float getSkyAngle(float tickDelta) {
-        if (SodiumExtraClientMod.options().extraSettings.dayTime) {
+        if (SodiumExtraClientMod.options().extraSettings.dayLightCycle) {
             return this.getDimension().getSkyAngle(this.getLevelProperties().getTimeOfDay());
         }
         return this.getDimension().getSkyAngle(5000L);

--- a/src/main/java/me/flashyreese/mods/sodiumextra/mixin/sodium/MixinSliderControl.java
+++ b/src/main/java/me/flashyreese/mods/sodiumextra/mixin/sodium/MixinSliderControl.java
@@ -1,5 +1,6 @@
 package me.flashyreese.mods.sodiumextra.mixin.sodium;
 
+import me.flashyreese.mods.sodiumextra.client.SodiumExtraClientMod;
 import me.jellysquid.mods.sodium.client.gui.options.Option;
 import me.jellysquid.mods.sodium.client.gui.options.control.ControlValueFormatter;
 import me.jellysquid.mods.sodium.client.gui.options.control.SliderControl;
@@ -23,7 +24,7 @@ public class MixinSliderControl {
      */
     @Inject(method = "<init>", at = @At(value = "TAIL"))
     public void init(Option<Integer> option, int min, int max, int interval, ControlValueFormatter mode, CallbackInfo ci){
-        if (mode == ControlValueFormatter.brightness()){
+        if (SodiumExtraClientMod.options().extraSettings.highMaxBrightness && mode == ControlValueFormatter.brightness()){
             this.max = 1000;
         }
     }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -9,7 +9,8 @@
   ],
   "contributors": [
     "AMereBagatelle",
-    "EatMyVenom"
+    "EatMyVenom",
+    "Madis0"
   ],
   "contact": {
     "sources": "https://github.com/FlashyReese/sodium-extra-fabric",


### PR DESCRIPTION
This PR attempts to fix #10 and some other minor things:

- Separates options that I consider cheaty to its own group in Extra tab
- Adds a config-only option `hideCheats` for toggling the visibility of the group (enabled by default as suggested by @DragonEggBedrockBreaking)
- Adds a default-disabled `highMaxBrightness` option (because with expanded slider even 100% is hard to set with mouse lol)
- Renames Show time to Daylight Cycle and adjusts its tooltip (I found the wording confusing, it sounded like it actually shows the game time as a label like it shows FPS, now it is worded like vanilla gamerule)
- Adds tooltips for Show FPS and Fog
- Adds my name to contributors list