### PR TITLE
Fog distance slider

### DIFF
--- a/src/main/java/me/flashyreese/mods/sodiumextra/client/gui/SodiumExtraGameOptionPages.java
+++ b/src/main/java/me/flashyreese/mods/sodiumextra/client/gui/SodiumExtraGameOptionPages.java
@@ -209,11 +209,11 @@ public class SodiumExtraGameOptionPages {
     public static OptionPage render() {
         List<OptionGroup> groups = new ArrayList<>();
         groups.add(OptionGroup.createBuilder()
-                .add(OptionImpl.createBuilder(boolean.class, sodiumExtraOpts)
+                .add(OptionImpl.createBuilder(int.class, sodiumExtraOpts)
                         .setName("Fog")
-                        .setTooltip("If enabled, a fog effect will be used for terrain in the distance. Disabling this option will not change fog effects used underwater or in the Nether.")
-                        .setControl(TickBoxControl::new)
-                        .setBinding((opts, value) -> opts.renderSettings.fog = value, opts -> opts.renderSettings.fog)
+                        .setTooltip("Adjusts the fog effect distance on the terrain. \n0 - use vanilla fog settings\n1-32 - set fog distance in chunks\n33 - max fog distance (essentially disables fog)\nWill not change the fog underwater or in the Nether.")
+                        .setControl(option -> new SliderControl(option, 0, 33, 1, ControlValueFormatter.number()))
+                        .setBinding((options, value) -> options.renderSettings.fogDistance = value, options -> options.renderSettings.fogDistance)
                         .build()
                 )
                 .add(OptionImpl.createBuilder(boolean.class, sodiumExtraOpts)

--- a/src/main/java/me/flashyreese/mods/sodiumextra/client/gui/SodiumExtraGameOptions.java
+++ b/src/main/java/me/flashyreese/mods/sodiumextra/client/gui/SodiumExtraGameOptions.java
@@ -126,7 +126,7 @@ public class SodiumExtraGameOptions {
     }
 
     public static class RenderSettings {
-        public boolean fog;
+        public int fogDistance;
         public boolean lightUpdates;
         public boolean itemFrame;
         public boolean armorStand;
@@ -134,7 +134,7 @@ public class SodiumExtraGameOptions {
         public boolean piston;
 
         public RenderSettings() {
-            this.fog = true;
+            this.fogDistance = 0;
             this.lightUpdates = true;
             this.itemFrame = true;
             this.armorStand = true;

--- a/src/main/java/me/flashyreese/mods/sodiumextra/mixin/features/fog/MixinBackgroundRenderer.java
+++ b/src/main/java/me/flashyreese/mods/sodiumextra/mixin/features/fog/MixinBackgroundRenderer.java
@@ -15,10 +15,18 @@ public class MixinBackgroundRenderer {
     @Inject(method = "applyFog", at = @At(value = "HEAD"), cancellable = true)
     private static void applyFog(Camera camera, BackgroundRenderer.FogType fogType, float viewDistance, boolean thickFog, CallbackInfo info) {
         if (fogType == BackgroundRenderer.FogType.FOG_TERRAIN) {
-            if (!SodiumExtraClientMod.options().renderSettings.fog) {
-                // Terrible hack, also breaks fog occlusion culling
+            if (SodiumExtraClientMod.options().renderSettings.fogDistance == 0) {
+                // Keep vanilla fog
+            }
+            else if (SodiumExtraClientMod.options().renderSettings.fogDistance == 33) {
+                // Terrible hack to disable the fog, also breaks fog occlusion culling
                 RenderSystem.setShaderFogStart(viewDistance * viewDistance);
                 RenderSystem.setShaderFogEnd(viewDistance * viewDistance + 1);
+                info.cancel();
+            }
+            else {
+                RenderSystem.setShaderFogStart(SodiumExtraClientMod.options().renderSettings.fogDistance * 16);
+                RenderSystem.setShaderFogEnd((SodiumExtraClientMod.options().renderSettings.fogDistance + 1) * 16);
                 info.cancel();
             }
         }

--- a/src/main/java/me/flashyreese/mods/sodiumextra/mixin/features/fog/MixinBackgroundRenderer.java
+++ b/src/main/java/me/flashyreese/mods/sodiumextra/mixin/features/fog/MixinBackgroundRenderer.java
@@ -15,16 +15,13 @@ public class MixinBackgroundRenderer {
     @Inject(method = "applyFog", at = @At(value = "HEAD"), cancellable = true)
     private static void applyFog(Camera camera, BackgroundRenderer.FogType fogType, float viewDistance, boolean thickFog, CallbackInfo info) {
         if (fogType == BackgroundRenderer.FogType.FOG_TERRAIN) {
-            if (SodiumExtraClientMod.options().renderSettings.fogDistance == 0) {
-                // Keep vanilla fog
-            }
-            else if (SodiumExtraClientMod.options().renderSettings.fogDistance == 33) {
+            if (SodiumExtraClientMod.options().renderSettings.fogDistance == 33) {
                 // Terrible hack to disable the fog, also breaks fog occlusion culling
-                RenderSystem.setShaderFogStart(viewDistance * viewDistance);
-                RenderSystem.setShaderFogEnd(viewDistance * viewDistance + 1);
+                // Todo: Per dimension fog toggles and sliders perhaps
+                RenderSystem.setShaderFogStart(Short.MAX_VALUE - 1);
+                RenderSystem.setShaderFogEnd(Short.MAX_VALUE);
                 info.cancel();
-            }
-            else {
+            } else if (SodiumExtraClientMod.options().renderSettings.fogDistance != 0){
                 RenderSystem.setShaderFogStart(SodiumExtraClientMod.options().renderSettings.fogDistance * 16);
                 RenderSystem.setShaderFogEnd((SodiumExtraClientMod.options().renderSettings.fogDistance + 1) * 16);
                 info.cancel();


### PR DESCRIPTION
Removes the fog toggle option and makes it a slider instead, calculated as value * 16 (aka in chunks). 0 uses vanilla fog settings, 33 uses the current "no fog" settings.

Fixes #36 