### PR TITLE
Distortion and FOV effects sliders

### DIFF
--- a/src/main/java/me/flashyreese/mods/sodiumextra/common/util/ControlValueFormatterExtended.java
+++ b/src/main/java/me/flashyreese/mods/sodiumextra/common/util/ControlValueFormatterExtended.java
@@ -29,4 +29,8 @@ public interface ControlValueFormatterExtended extends ControlValueFormatter {
             }
         };
     }
+
+    static ControlValueFormatter percentageOff(){ // Already exists in Sodium's dev branch, but that version is not released yet
+        return (v) -> (v > 0) ? v + "%" : new TranslatableText("options.off").getString();
+    }
 }

--- a/src/main/java/me/flashyreese/mods/sodiumextra/mixin/sodium/MixinSodiumGameOptionPages.java
+++ b/src/main/java/me/flashyreese/mods/sodiumextra/mixin/sodium/MixinSodiumGameOptionPages.java
@@ -75,7 +75,7 @@ public class MixinSodiumGameOptionPages {
                         .setName(new TranslatableText("options.fovEffectScale"))
                         .setTooltip(new TranslatableText("options.fovEffectScale.tooltip"))
                         .setControl(option -> new SliderControl(option, 0, 100, 1, ControlValueFormatter.percentage()))
-                        .setBinding((opts, value) -> opts.fovEffectScale = (float) Math.sqrt(value * 0.01D), (opts) -> (int) (Math.pow(opts.fovEffectScale, 2.0D) / 0.01D))
+                        .setBinding((opts, value) -> opts.fovEffectScale = (float) Math.sqrt(value / 100.0F), (opts) -> Math.round(Math.pow(opts.fovEffectScale, 2.0D) * 100.0F))
                         .setImpact(OptionImpact.LOW)
                         .build()
                 )

--- a/src/main/java/me/flashyreese/mods/sodiumextra/mixin/sodium/MixinSodiumGameOptionPages.java
+++ b/src/main/java/me/flashyreese/mods/sodiumextra/mixin/sodium/MixinSodiumGameOptionPages.java
@@ -4,6 +4,8 @@ import me.flashyreese.mods.sodiumextra.client.gui.options.control.SliderControlE
 import me.flashyreese.mods.sodiumextra.common.util.ControlValueFormatterExtended;
 import me.jellysquid.mods.sodium.client.gui.SodiumGameOptionPages;
 import me.jellysquid.mods.sodium.client.gui.options.*;
+import me.jellysquid.mods.sodium.client.gui.options.control.ControlValueFormatter;
+import me.jellysquid.mods.sodium.client.gui.options.control.SliderControl;
 import me.jellysquid.mods.sodium.client.gui.options.storage.MinecraftOptionsStorage;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.util.VideoMode;
@@ -55,6 +57,28 @@ public class MixinSodiumGameOptionPages {
                         .setFlags(OptionFlag.REQUIRES_GAME_RESTART)
                         .setImpact(OptionImpact.HIGH)
                         .build())
+                .build());
+    }
+
+    @Inject(method = "quality", at = @At(value = "INVOKE", target = "Lme/jellysquid/mods/sodium/client/gui/options/OptionGroup;createBuilder()Lme/jellysquid/mods/sodium/client/gui/options/OptionGroup$Builder;", ordinal = 2, shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILSOFT, remap = false)
+    private static void quality(CallbackInfoReturnable<OptionPage> cir, List<OptionGroup> groups){
+        groups.add(OptionGroup.createBuilder()
+                .add(OptionImpl.createBuilder(int.class, vanillaOpts)
+                        .setName(new TranslatableText("options.screenEffectScale"))
+                        .setTooltip(new TranslatableText("options.screenEffectScale.tooltip"))
+                        .setControl(option -> new SliderControl(option, 0, 100, 1, ControlValueFormatterExtended.percentageOff()))
+                        .setBinding((opts, value) -> opts.distortionEffectScale = (float) (value * 0.01D), (opts) -> (int) (opts.distortionEffectScale / 0.01D))
+                        .setImpact(OptionImpact.LOW)
+                        .build()
+                )
+                .add(OptionImpl.createBuilder(int.class, vanillaOpts)
+                        .setName(new TranslatableText("options.fovEffectScale"))
+                        .setTooltip(new TranslatableText("options.fovEffectScale.tooltip"))
+                        .setControl(option -> new SliderControl(option, 0, 100, 1, ControlValueFormatter.percentage()))
+                        .setBinding((opts, value) -> opts.fovEffectScale = (float) Math.sqrt(value * 0.01D), (opts) -> (int) (Math.pow(opts.fovEffectScale, 2.0D) / 0.01D))
+                        .setImpact(OptionImpact.LOW)
+                        .build()
+                )
                 .build());
     }
 }

--- a/src/main/java/me/flashyreese/mods/sodiumextra/mixin/sodium/MixinSodiumGameOptionPages.java
+++ b/src/main/java/me/flashyreese/mods/sodiumextra/mixin/sodium/MixinSodiumGameOptionPages.java
@@ -67,7 +67,7 @@ public class MixinSodiumGameOptionPages {
                         .setName(new TranslatableText("options.screenEffectScale"))
                         .setTooltip(new TranslatableText("options.screenEffectScale.tooltip"))
                         .setControl(option -> new SliderControl(option, 0, 100, 1, ControlValueFormatterExtended.percentageOff()))
-                        .setBinding((opts, value) -> opts.distortionEffectScale = (float) (value * 0.01D), (opts) -> (int) (opts.distortionEffectScale / 0.01D))
+                        .setBinding((opts, value) -> opts.distortionEffectScale = (float) value / 100.0F, (opts) -> Math.round(opts.distortionEffectScale * 100.0F))
                         .setImpact(OptionImpact.LOW)
                         .build()
                 )

--- a/src/main/java/me/flashyreese/mods/sodiumextra/mixin/sodium/MixinSodiumGameOptionPages.java
+++ b/src/main/java/me/flashyreese/mods/sodiumextra/mixin/sodium/MixinSodiumGameOptionPages.java
@@ -75,7 +75,7 @@ public class MixinSodiumGameOptionPages {
                         .setName(new TranslatableText("options.fovEffectScale"))
                         .setTooltip(new TranslatableText("options.fovEffectScale.tooltip"))
                         .setControl(option -> new SliderControl(option, 0, 100, 1, ControlValueFormatter.percentage()))
-                        .setBinding((opts, value) -> opts.fovEffectScale = (float) Math.sqrt(value / 100.0F), (opts) -> Math.round(Math.pow(opts.fovEffectScale, 2.0D) * 100.0F))
+                        .setBinding((opts, value) -> opts.fovEffectScale = (float) Math.sqrt(value / 100.0F), (opts) -> Math.round((int) Math.pow(opts.fovEffectScale, 2.0D) * 100.0F))
                         .setImpact(OptionImpact.LOW)
                         .build()
                 )


### PR DESCRIPTION
Adds "Distortion effects" and "FOV effects" sliders to Sodium's Graphics tab.
Currently suffers the same rounding issues as my Sodium's PR.