### PR TITLE
Update Fabric API name

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -39,7 +39,7 @@
   ],
   "depends": {
     "fabricloader": ">=0.14",
-    "fabric": "*",
+    "fabric-api": "*",
     "sodium": ">=0.4.1"
   },
   "breaks": {


### PR DESCRIPTION
#290 but 1.18.2. You can't backport it any further though.