### PR TITLE
Update CI dependencies, Improve CI configurations.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,18 +7,19 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
+      - name: Checkout Repository
       - uses: actions/checkout@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 17
-      - name: Grant execute permission for Gradlew
-        run: chmod +x gradlew
       - name: Build with Gradle
-        run: ./gradlew build
-      - name: Upload build artifacts
+        run: |
+          chmod +x gradlew
+          ./gradlew build
+      - name: Upload Build Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: build-artifacts
+          name: 'Sodium Extra Artifacts'
           path: build/libs

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-      - uses: actions/checkout@v3
+        uses: actions/checkout@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,23 +9,23 @@ jobs:
   build:
     runs-on: self-hosted
     steps:
-      - name: Checkout sources
+      - name: Checkout Repository
         uses: actions/checkout@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 17
-      - name: Grant execute permission for Gradlew
-        run: chmod +x gradlew
       - name: Upload assets to releases
-        run: ./gradlew build publishAllPublicationsToFlashyReeseReleasesRepository
+        run: |
+          chmod +x gradlew
+          ./gradlew build publishAllPublicationsToFlashyReeseReleasesRepository
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
           BUILD_RELEASE: ${{ github.event.prerelease == false }}
       - name: Publish to Modrinth & CurseForge
-        uses: Kir-Antipov/mc-publish@v3.2
+        uses: Kir-Antipov/mc-publish@v3.3
         with:
           modrinth-id: PtjYWJkn
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
@@ -36,9 +36,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
           version-type: release
-
           loaders: fabric
-
           version-resolver: latest
           dependencies: |
             sodium | depends | *

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,8 @@ on:
       - published
 
 jobs:
-  build:
+  publish:
+    if: github.repository_owner == 'FlashyReese'
     runs-on: self-hosted
     steps:
       - name: Checkout Repository

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -3,7 +3,8 @@ name: Self-Hosted runner CI with Gradle
 on: [ push ]
 
 jobs:
-  build:
+  selfhost-build:
+    if: github.repository_owner == 'FlashyReese'
     runs-on: self-hosted
 
     steps:

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -7,18 +7,19 @@ jobs:
     runs-on: self-hosted
 
     steps:
+      - name: Checkout Repository
       - uses: actions/checkout@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 17
-      - name: Grant execute permission for Gradlew
-        run: chmod +x gradlew
       - name: Build with Gradle
-        run: ./gradlew build
-      - name: Upload build artifacts
+        run: |
+          chmod +x gradlew
+          ./gradlew build
+      - name: Upload Auild Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: build-artifacts
+          name: 'Sodium Extra Artifacts'
           path: build/libs

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-      - uses: actions/checkout@v3
+        uses: actions/checkout@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
     id 'signing'
     id 'fabric-loom' version '1.2-SNAPSHOT'
     id 'maven-publish'
-    id 'io.github.juuxel.loom-quiltflower' version '1.8.0'
+    id 'io.github.juuxel.loom-quiltflower' version '1.10.0'
 }
 
 apply plugin: 'de.guntram.mcmod.crowdin-translate'

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
     # check these on https://modmuss50.me/fabric.html
     minecraft_version=1.20.1
-    yarn_mappings=1.20.1+build.8
+    yarn_mappings=1.20.1+build.9
     loader_version=0.14.21
 
 # Mod Properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,5 +14,5 @@ org.gradle.jvmargs=-Xmx1G
 # Dependencies
     reeses_sodium_options=1.5.1+mc1.20-build.74
     sodium_version=mc1.20-0.4.10
-    fabric_version=0.84.0+1.20.1
+    fabric_version=0.85.0+1.20.1
     crowdin_translate=1.4+1.19.3


### PR DESCRIPTION
1. The publishing and self-hosting scripts can now only be ran when commits are done on the original repository itself,
2. Friendly names will be shipped into all CI steps to properly describe them,
3. The chmod requirement will be merged into the build step as we do not need a seperate step for it specifically,
4. The mc-publish script will be updated from v3.2 to v3.3,
5. Yarn will be updated from build 8 to build 9,
6. Quiltflower will be updated from 1.8.0 to 1.10.0, *(This part requires testing)*
7. Fabric API will be updated from 0.84.0 to 0.85.0.

This pull request can be synced over to Reese's sodium options, Command aliases and FabricSkyboxes-InterOP repos if you wish to do that on post-merge.