### PR TITLE
[1.20] Update Minecraft wiki link to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For more information on using Crowdin, please see their "[Intro For Volunteer Tr
 We sincerely apologize. Translations are community submitted, and despite our best efforts, vandalism will occasionally slip through. Please [open an issue](#issues) explaining, and it will be removed as soon as possible.
 
 #### How can I suggest a new language to add for translation?
-Thank you for your interest! Please [open an issue](#issues) with the [in-game Locale Code](https://minecraft.fandom.com/wiki/Language#Languages) from the linked table. We've kept the number of languages relatively small to set a reasonable starting goal, and will add more as requests come in.
+Thank you for your interest! Please [open an issue](#issues) with the [in-game Locale Code](https://minecraft.wiki/w/Language#Languages) from the linked table. We've kept the number of languages relatively small to set a reasonable starting goal, and will add more as requests come in.
 
 ## License
 Sodium Extra is licensed under GNU LGPLv3, a free and open-source license. For more information, please see the [license file](LICENSE.txt).


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the old wiki link accordingly.