### PR TITLE
Add Player Facing Tip Decoration for  HUD show_coordinates

### DIFF
--- a/common/src/main/java/me/flashyreese/mods/sodiumextra/client/gui/SodiumExtraHud.java
+++ b/common/src/main/java/me/flashyreese/mods/sodiumextra/client/gui/SodiumExtraHud.java
@@ -34,8 +34,31 @@ public class SodiumExtraHud {
 
         if (SodiumExtraClientMod.options().extraSettings.showCoords && this.client.player != null) {
             Vec3 pos = this.client.player.position();
+            var facing = this.client.player.getViewVector(1.0f);
 
-            Component text = Component.translatable("sodium-extra.overlay.coordinates", String.format("%.2f", pos.x), String.format("%.2f", pos.y), String.format("%.2f", pos.z));
+            var xDecor = facing.x > 0 ? "+" : facing.x < 0 ? "-" : "";
+            var yDecor = facing.y > 0 ? "+" : facing.y < 0 ? "-" : "";
+            var zDecor = facing.z > 0 ? "+" : facing.z < 0 ? "-" : "";
+
+            if (Math.abs(facing.y) > Math.abs(facing.x)
+                    && Math.abs(facing.y) > Math.abs(facing.z)) {
+                yDecor = "*" + yDecor;
+            }
+
+            if (Math.abs(facing.x) > Math.abs(facing.z)) {
+                xDecor = "*" + xDecor;
+            } else if (Math.abs(facing.x) == Math.abs(facing.z)) {
+                xDecor = "*" + xDecor;
+                zDecor = "*" + xDecor;
+            } else {
+                zDecor = "*" + xDecor;
+            }
+
+            Component text = Component.translatable("sodium-extra.overlay.coordinates"
+                    , xDecor, String.format("%.2f", pos.x)
+                    , yDecor, String.format("%.2f", pos.y)
+                    , zDecor, String.format("%.2f", pos.z)
+            );
             if (this.client.showOnlyReducedInfo()) {
                 text = Component.literal("Cords not available due to reducedDebugInfo: true."); // Todo: Localize?
             }

--- a/common/src/main/resources/assets/sodium-extra/lang/cs_cz.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/cs_cz.json
@@ -336,7 +336,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "Pokud je zvoleno, V-Sync bude moci změnit snímek uprostřed vykreslování a vypnout sám sebe. Obvykle znatelně pomáhá zlepšit reakci. Může způsobovat problémy s některými GPU.",
   "sodium-extra.option.use_fast_random": "Použít rychlý náhodný výběr",
   "sodium-extra.option.use_fast_random.tooltip": "Při povolení bude pro vykreslování bloků použita rychlá náhodná funkce. Toto může ovlivnit rotaci náhodně otočených textur při porovnání s vanillou.",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(max. %s / prům. %s / min. %s)",
   "sodium-extra.overlay.light_updates": "Aktualizace světel zakázány",

--- a/common/src/main/resources/assets/sodium-extra/lang/de_at.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/de_at.json
@@ -330,7 +330,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "If enabled, V-Sync will be able to swap mid-frame and disable itself at times, usually notably helping responsiveness. May cause issues with some GPU drivers.",
   "sodium-extra.option.use_fast_random": "Schnellen Zufallsgenerator verwenden",
   "sodium-extra.option.use_fast_random.tooltip": "Falls aktiviert wird eine schnelle Zufallsgeneratorfunktion für das Block-Rendering genutzt. Dies kann die Rotation von einigen zufällig gedrehten Texturen im Vergleich zum Vanilla-Verhalten verändern.",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(Max. %s / Dsl. %s / Min. %s)",
   "sodium-extra.overlay.light_updates": "Schatten Aktualisierung deaktiviert",

--- a/common/src/main/resources/assets/sodium-extra/lang/de_ch.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/de_ch.json
@@ -330,7 +330,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "If enabled, V-Sync will be able to swap mid-frame and disable itself at times, usually notably helping responsiveness. May cause issues with some GPU drivers.",
   "sodium-extra.option.use_fast_random": "Schnellen Zufallsgenerator verwenden",
   "sodium-extra.option.use_fast_random.tooltip": "Falls aktiviert wird eine schnelle Zufallsgeneratorfunktion für das Block-Rendering genutzt. Dies kann die Rotation von einigen zufällig gedrehten Texturen im Vergleich zum Vanilla-Verhalten verändern.",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(Max. %s / Dsl. %s / Min. %s)",
   "sodium-extra.overlay.light_updates": "Schatten Aktualisierung deaktiviert",

--- a/common/src/main/resources/assets/sodium-extra/lang/de_de.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/de_de.json
@@ -336,7 +336,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "If enabled, V-Sync will be able to swap mid-frame and disable itself at times, usually notably helping responsiveness. May cause issues with some GPU drivers.",
   "sodium-extra.option.use_fast_random": "Schnellen Zufallsgenerator verwenden",
   "sodium-extra.option.use_fast_random.tooltip": "Falls aktiviert wird eine schnelle Zufallsgeneratorfunktion für das Block-Rendering genutzt. Dies kann die Rotation von einigen zufällig gedrehten Texturen im Vergleich zum Vanilla-Verhalten verändern.",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(Max. %s / Dsl. %s / Min. %s)",
   "sodium-extra.overlay.light_updates": "Schatten Aktualisierung deaktiviert",

--- a/common/src/main/resources/assets/sodium-extra/lang/el_gr.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/el_gr.json
@@ -336,7 +336,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "If enabled, V-Sync will be able to swap mid-frame and disable itself at times, usually notably helping responsiveness. May cause issues with some GPU drivers.",
   "sodium-extra.option.use_fast_random": "Use Fast Random",
   "sodium-extra.option.use_fast_random.tooltip": "If enabled, a fast random function will be used for block rendering. This can affect the rotation of randomly rotated textures when compared to vanilla.",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(max. %s / avg. %s / min. %s)",
   "sodium-extra.overlay.light_updates": "Light updates disabled",

--- a/common/src/main/resources/assets/sodium-extra/lang/en_us.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/en_us.json
@@ -336,7 +336,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "If enabled, V-Sync will be able to swap mid-frame and disable itself at times, usually notably helping responsiveness. May cause issues with some GPU drivers.",
   "sodium-extra.option.use_fast_random": "Use Fast Random",
   "sodium-extra.option.use_fast_random.tooltip": "If enabled, a fast random function will be used for block rendering. This can affect the rotation of randomly rotated textures when compared to vanilla.",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(max. %s / avg. %s / min. %s)",
   "sodium-extra.overlay.light_updates": "Light updates disabled",

--- a/common/src/main/resources/assets/sodium-extra/lang/es_ar.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/es_ar.json
@@ -336,7 +336,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "If enabled, V-Sync will be able to swap mid-frame and disable itself at times, usually notably helping responsiveness. May cause issues with some GPU drivers.",
   "sodium-extra.option.use_fast_random": "Use Fast Random",
   "sodium-extra.option.use_fast_random.tooltip": "If enabled, a fast random function will be used for block rendering. This can affect the rotation of randomly rotated textures when compared to vanilla.",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(max. %s / avg. %s / min. %s)",
   "sodium-extra.overlay.light_updates": "Light updates disabled",

--- a/common/src/main/resources/assets/sodium-extra/lang/es_mx.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/es_mx.json
@@ -336,7 +336,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "Si está habilitado, V-Sync podrá cambiar la fotograma media y deshabilitarse a sí mismo a veces, lo que generalmente ayuda notablemente a la tiempo de respuesta. Puede causar problemas con algunos controladores de GPU.",
   "sodium-extra.option.use_fast_random": "Utilice aleatorio rápido",
   "sodium-extra.option.use_fast_random.tooltip": "Si está habilitada, se utilizará una función aleatoria rápida para la representación de bloques. Esto puede afectar la rotación de texturas rotadas aleatoriamente en comparación con vainilla.",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(max. %s / prom. %s / min. %s)",
   "sodium-extra.overlay.light_updates": "Actualizaciones de iluminación deshabilitado",

--- a/common/src/main/resources/assets/sodium-extra/lang/et_ee.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/et_ee.json
@@ -336,7 +336,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "Lubamisel saab V-Sync keset kaadrit vahetuda ning end vajadusel keelata, tõstes jõudlust üldjuhul märgatavalt. Võib põhjustada teatud graafikakaardidraiveritega probleeme.",
   "sodium-extra.option.use_fast_random": "Kasuta kiiret juhuslikkust",
   "sodium-extra.option.use_fast_random.tooltip": "Lubamisel kasutatakse plokkide renderdamiseks kiiret juhuslikkuse meetodit. See võib muuta juhuslikult pööratud tekstuuride pöördenurga vanillist erinevaks.",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "%s k/s",
   "sodium-extra.overlay.fps_extended": "(max. %s / kesk. %s / min. %s)",
   "sodium-extra.overlay.light_updates": "Valguse uuendused keelatud",

--- a/common/src/main/resources/assets/sodium-extra/lang/fi_fi.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/fi_fi.json
@@ -336,7 +336,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "Jos käytössä, V-sync voi vaihtua kesken kuvan ja poistaa itsensä käytöstä, mikä yleensä helpottaa reagoivuutta huomattavasti. Saattaa aiheuttaa ongelmia joidenkin näytönohjainten ajurien kanssa.",
   "sodium-extra.option.use_fast_random": "Käytä nopeaa satunnaisgeneraattoria",
   "sodium-extra.option.use_fast_random.tooltip": "Jos käytössä, nopeampaa satunnaislukugeneraattoria käytetään palikoide piirtämiseen. Tämä voi vaikuttaa satunnaisten tekstuurien kiertoihin verrattuna tavalliseen.",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(max. %s / avg. %s / min. %s)",
   "sodium-extra.overlay.light_updates": "Valotason päivitykset pois päältä",

--- a/common/src/main/resources/assets/sodium-extra/lang/hu_hu.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/hu_hu.json
@@ -336,7 +336,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "Ha be van kapcsolva V-Sync dinamikusan ki-be fog kapcsolódni a képkockák közben sokszor nagyon segítve a érzékenységet. Problémákat okozhaz néhány GPU-val.",
   "sodium-extra.option.use_fast_random": "Gyors Random használata",
   "sodium-extra.option.use_fast_random.tooltip": "Ha be van kapcsolva egy gyors random folyamat lesz használva a blokkok megjelenítésére. Ez befolyásolhatja a random elforgatott textúrákat a vanillához mérve.",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(max. %s / átl. %s / min. %s)",
   "sodium-extra.overlay.light_updates": "A Világítás Frissülése ki van kapcsolva.",

--- a/common/src/main/resources/assets/sodium-extra/lang/it_it.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/it_it.json
@@ -336,7 +336,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "Se abilitato, il V-Sync sarà in grado di scambiare mid-frame e di disabilitarsi a volte, solitamente migliorando la reattività. Può causare problemi con alcuni driver GPU.",
   "sodium-extra.option.use_fast_random": "Usa Random Veloce",
   "sodium-extra.option.use_fast_random.tooltip": "Se abilitata, verrà utilizzata una funzione random veloce per il rendering dei blocchi. Questo può influenzare la rotazione delle texture ruotate casualmente rispetto alla vanilla.",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(max. %s / med. %s / min. %s)",
   "sodium-extra.overlay.light_updates": "Aggiornamenti della luce disabilitati",

--- a/common/src/main/resources/assets/sodium-extra/lang/ja_jp.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/ja_jp.json
@@ -336,7 +336,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "有効にした場合、垂直同期が描画をフレームの途中でスワップし、時にはそれ自体を無効にすることが出来ます。通常は顕著に応答性を向上させます。一部のGPUドライバーで問題が発生する可能性があります。",
   "sodium-extra.option.use_fast_random": "高速な乱数を使う",
   "sodium-extra.option.use_fast_random.tooltip": "有効にした場合、高速な乱数関数がブロックレンダリングに使用されます。バニラと比較したとき、ランダムに回転するテクスチャの向きに影響を与える可能性があります。",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(最大 %s / 平均 %s / 最小 %s)",
   "sodium-extra.overlay.light_updates": "光の状態更新が無効",

--- a/common/src/main/resources/assets/sodium-extra/lang/ko_kr.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/ko_kr.json
@@ -336,7 +336,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "활성화하면, 필요에 따라 프레임을 낮추거나 수직 동기화가 비활성화 되어 응답 속도를 개선할 수 있습니다. 일부 그래픽 드라이버에서 문제를 일으킬 수 있습니다.",
   "sodium-extra.option.use_fast_random": "빠른 무작위 함수 사용",
   "sodium-extra.option.use_fast_random.tooltip": "활성화하면, 블록 렌더링에 빠른 무작위 함수가 사용됩니다. 무작위로 회전되는 텍스쳐의 회전 방향이 바닐라와 다를 수 있습니다.",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(최대 %s / 평균 %s / 최소 %s)",
   "sodium-extra.overlay.light_updates": "조명 업데이트 비활성화됨",

--- a/common/src/main/resources/assets/sodium-extra/lang/ms_my.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/ms_my.json
@@ -336,7 +336,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "Jika didayakan, V-Sync akan dapat menukar pada pertengahan bingkai dan menyahdayakan dirinya pada masa-masa tertentu, terutamanya membantu tahap keresponsifan. Boleh menyebabkan masalah dengan sesetengah pemacu GPU.",
   "sodium-extra.option.use_fast_random": "Guna Rawak Pantas",
   "sodium-extra.option.use_fast_random.tooltip": "Jika didayakan, fungsi rawak yang pantas akan digunakan untuk memaparkan blok. Ini boleh menjejaskan putaran tekstur yang diputar secara rawak jika dibandingkan dengan vanila.",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "%s BPS",
   "sodium-extra.overlay.fps_extended": "(maks. %s / purata %s / min. %s)",
   "sodium-extra.overlay.light_updates": "Kemas kini cahaya dinyahdayakan",

--- a/common/src/main/resources/assets/sodium-extra/lang/pl_pl.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/pl_pl.json
@@ -336,7 +336,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "Jeśli ta opcja jest włączona, V-Sync będzie w stanie zamienić środkową klatkę i czasami się wyłączyć, zwykle w szczególności poprawiając szybkość reakcji. Może powodować problemy z niektórymi sterownikami GPU.",
   "sodium-extra.option.use_fast_random": "Użyj szybkiej losowości",
   "sodium-extra.option.use_fast_random.tooltip": "Jeśli ta opcja jest włączona, do renderowania bloków zostanie użyta szybka funkcja losowa. Może to wpłynąć na rotację losowo obracanych tekstur w porównaniu z domyślnym ustawieniem.",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(maks. %s / śr. %s / min. %s)",
   "sodium-extra.overlay.light_updates": "Aktualizacje oświetlenia wyłączone",

--- a/common/src/main/resources/assets/sodium-extra/lang/pt_br.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/pt_br.json
@@ -336,7 +336,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "Ao ativar, a sincronização vertical poderá alternar o meio do quadro e ser desativada às vezes, otimizando a capacidade de resposta. Pode causar problemas em algumas placas gráficas.",
   "sodium-extra.option.use_fast_random": "Aleatoriedade rápida",
   "sodium-extra.option.use_fast_random.tooltip": "Ao ativar, uma função rápida aleatória será usada na renderização de blocos. Pode afetar a rotação de texturas giradas aleatoriamente em comparação com o padrão.",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "FPS: %s",
   "sodium-extra.overlay.fps_extended": "(máx. %s / méd. %s / mín. %s)",
   "sodium-extra.overlay.light_updates": "Atualizações de luz desativadas",

--- a/common/src/main/resources/assets/sodium-extra/lang/pt_pt.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/pt_pt.json
@@ -330,7 +330,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "Ao ativar, a sincronização vertical poderá alternar o meio do quadro e ser desativada às vezes, otimizando a capacidade de resposta. Pode causar problemas em algumas placas gráficas.",
   "sodium-extra.option.use_fast_random": "Aleatoriedade rápida",
   "sodium-extra.option.use_fast_random.tooltip": "Ao ativar, uma função rápida aleatória será usada na renderização de blocos. Pode afetar a rotação de texturas giradas aleatoriamente em comparação com o padrão.",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "FPS: %s",
   "sodium-extra.overlay.fps_extended": "(máx. %s / méd. %s / mín. %s)",
   "sodium-extra.overlay.light_updates": "Atualizações de luz desativadas",

--- a/common/src/main/resources/assets/sodium-extra/lang/ru_ru.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/ru_ru.json
@@ -336,7 +336,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "Вертикальная синхронизация сможет переключаться между кадрами и время от времени отключаться, что обычно заметно улучшает быстродействие. Может привести к проблемам с некоторыми графическими драйверами.",
   "sodium-extra.option.use_fast_random": "Использовать быстрый рандом",
   "sodium-extra.option.use_fast_random.tooltip": "Если включено, для рендеринга блоков будет использоваться функция быстрого рандома. Это может повлиять на видимое положение случайно повёрнутых текстур по сравнению с немодифицированной игрой.",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(макс. %s / сред. %s / мин. %s)",
   "sodium-extra.overlay.light_updates": "Обновления света отключены",

--- a/common/src/main/resources/assets/sodium-extra/lang/th_th.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/th_th.json
@@ -336,7 +336,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "เมื่อเปิดตัวเลือกนี้ V-Sync จะสามารถสลับไปยังอัตราเฟรมระดับกลางและปิดตัวเองในบางเวลาได้ ช่วยในเรื่องของการตอบสนองของเกมได้อย่างเห็นได้ชัด แต่อาจมีปัญหากับไดรเวอร์ของการ์ดจอบางตัว",
   "sodium-extra.option.use_fast_random": "ใช้การสุ่มเร็ว",
   "sodium-extra.option.use_fast_random.tooltip": "ถ้าเปิดตัวเลือกนี้ ฟังก์ชั่นการสุ่มเร็วจะถูกใช้ในการเรนเดอร์บล็อกต่าง ๆ ตัวเลือกนี้จะมีผลต่อการหมุนพื้นผิวแบบสุ่มอีกด้วยเมื่อเทียบกับแบบวานิลลา",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(สูง %s / กลาง %s / ต่ำ %s)",
   "sodium-extra.overlay.light_updates": "ปิดการอัพเดตของแสงแล้ว",

--- a/common/src/main/resources/assets/sodium-extra/lang/tr_tr.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/tr_tr.json
@@ -336,7 +336,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "Etkinleştirilirse, V-Sync kare ortasında geçiş yapabilir ve zaman zaman kendini devre dışı bırakabilir, genellikle yanıt verme hızına önemli ölçüde yardımcı olur. Bazı GPU sürücülerinde sorunlara neden olabilir.",
   "sodium-extra.option.use_fast_random": "Hızlı Olasılık Dağılımı Kullan",
   "sodium-extra.option.use_fast_random.tooltip": "Etkin ise, bir hızlı olasılık dağılım fonksiyonu blok görüntülemesi için kullanılacak. Bu ayar, vanillaya göre rastgele döndürülmüş dokuların rotasyonunu etkileyecektir.",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(mak. %s / ort. %s / min. %s)",
   "sodium-extra.overlay.light_updates": "Işık güncellemeleri devre dışı",

--- a/common/src/main/resources/assets/sodium-extra/lang/uk_ua.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/uk_ua.json
@@ -336,7 +336,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "Якщо ввімкнено, V-Sync зможе змінювати середину кадру і вимикати себе час від часу. Зазвичай, сильно збільшує швидкодію. Цей параметр може створювати проблеми з певними драйверами відеокарт.",
   "sodium-extra.option.use_fast_random": "Швидка випадковість",
   "sodium-extra.option.use_fast_random.tooltip": "Якщо ввімкнено, для промальовки блоків використовуватиметься функція швидкої випадковості. Це може вплинути на положення випадково повернутих текстур у порівнянні з ваніллю.",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(макс.: %s / серед.: %s / мін.: %s)",
   "sodium-extra.overlay.light_updates": "Оновлення світла вимкнено",

--- a/common/src/main/resources/assets/sodium-extra/lang/vi_vn.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/vi_vn.json
@@ -336,7 +336,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "Khi bật, V-Sync sẽ có thể tự hoán đổi giữa các khung hình hoặc tự vô hiệu hóa, giúp cải thiện đáng kể tốc độ phản hồi. Có thể gây ra vấn đề với một số trình điều khiển GPU.",
   "sodium-extra.option.use_fast_random": "Sử dụng tạo ngẫu nhiên nhanh",
   "sodium-extra.option.use_fast_random.tooltip": "Khi bật, một hàm ngẫu nhiên nhanh hơn sẽ được sử dụng. Việc này có thể ảnh hưởng đến chiều xoay của các hoạ tiết so với cách mặc định.",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(cao %s / t.bình %s / thấp %s)",
   "sodium-extra.overlay.light_updates": "Cập nhật chiếu sáng bị tắt",

--- a/common/src/main/resources/assets/sodium-extra/lang/zh_cn.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/zh_cn.json
@@ -336,7 +336,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "启用后，垂直同步将能够交换中间帧，并有时禁用自己，通常有助于响应。可能会与一些GPU驱动程序发生问题。",
   "sodium-extra.option.use_fast_random": "快速随机纹理",
   "sodium-extra.option.use_fast_random.tooltip": "启用后, 将使用快速随机函数来渲染方块。与原版相比, 这会影响随机旋转纹理的旋转方向。",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(最大 %s / 平均 %s / 最小 %s)",
   "sodium-extra.overlay.light_updates": "光照更新已禁用",

--- a/common/src/main/resources/assets/sodium-extra/lang/zh_hk.json
+++ b/common/src/main/resources/assets/sodium-extra/lang/zh_hk.json
@@ -330,7 +330,7 @@
   "sodium-extra.option.use_adaptive_sync.tooltip": "启用后，垂直同步将能够交换中间帧，并有时禁用自己，通常有助于响应。可能会与一些GPU驱动程序发生问题。",
   "sodium-extra.option.use_fast_random": "快速随机纹理",
   "sodium-extra.option.use_fast_random.tooltip": "启用后, 将使用快速随机函数来渲染方块。与原版相比, 这会影响随机旋转纹理的旋转方向。",
-  "sodium-extra.overlay.coordinates": "X: %s, Y: %s, Z: %s",
+  "sodium-extra.overlay.coordinates": "%sX: %s, %sY: %s, %sZ: %s",
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(最大 %s / 平均 %s / 最小 %s)",
   "sodium-extra.overlay.light_updates": "光照更新已禁用",


### PR DESCRIPTION
When facing direction vector on x is increase will add a '+' Decoration before X When facing direction vector on x is decrease will add a '-' Decoration before X

Same For axis y and z

When facing north-west mo close to west show a '*' Decoration be fore X

Finally look's like
*+X: 12, +Y:45, -Z:16