### PR TITLE
Update fog type option IDs to use Locale.ROOT

### DIFF
--- a/common/src/main/java/me/flashyreese/mods/sodiumextra/client/config/SodiumExtraConfig.java
+++ b/common/src/main/java/me/flashyreese/mods/sodiumextra/client/config/SodiumExtraConfig.java
@@ -17,10 +17,7 @@ import net.minecraft.network.chat.ComponentUtils;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.material.FogType;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class SodiumExtraConfig implements ConfigEntryPoint {

--- a/common/src/main/java/me/flashyreese/mods/sodiumextra/client/config/SodiumExtraConfig.java
+++ b/common/src/main/java/me/flashyreese/mods/sodiumextra/client/config/SodiumExtraConfig.java
@@ -311,7 +311,7 @@ public class SodiumExtraConfig implements ConfigEntryPoint {
                 .filter(type -> type != FogType.NONE)
                 .forEach(fogType -> {
                     // Environment Start
-                    IntegerOptionBuilder envStart = builder.createIntegerOption(id(fogType.name().toLowerCase() + "_environment_start"))
+                    IntegerOptionBuilder envStart = builder.createIntegerOption(id(fogType.name().toLowerCase(Locale.ROOT) + "_environment_start"))
                             .setEnabled(SodiumExtraClientMod.mixinConfig().getOptions().get("mixin.fog").isEnabled())
                             .setName(Component.translatable("sodium-extra.option.fog_type.environment_start", fogTypeName(fogType)))
                             .setTooltip(Component.translatable("sodium-extra.option.fog_type.environment_start.tooltip"))
@@ -326,7 +326,7 @@ public class SodiumExtraConfig implements ConfigEntryPoint {
                             .setValueFormatter(ControlValueFormatterImpls.percentage());
 
                     // Environment End
-                    IntegerOptionBuilder envEnd = builder.createIntegerOption(id(fogType.name().toLowerCase() + "_environment_end"))
+                    IntegerOptionBuilder envEnd = builder.createIntegerOption(id(fogType.name().toLowerCase(Locale.ROOT) + "_environment_end"))
                             .setEnabled(SodiumExtraClientMod.mixinConfig().getOptions().get("mixin.fog").isEnabled())
                             .setName(Component.translatable("sodium-extra.option.fog_type.environment_end", fogTypeName(fogType)))
                             .setTooltip(Component.translatable("sodium-extra.option.fog_type.environment_end.tooltip"))
@@ -341,7 +341,7 @@ public class SodiumExtraConfig implements ConfigEntryPoint {
                             .setValueFormatter(ControlValueFormatterImpls.percentage());
 
                     // Render Start
-                    IntegerOptionBuilder renderStart = builder.createIntegerOption(id(fogType.name().toLowerCase() + "_render_distance_start"))
+                    IntegerOptionBuilder renderStart = builder.createIntegerOption(id(fogType.name().toLowerCase(Locale.ROOT) + "_render_distance_start"))
                             .setEnabled(SodiumExtraClientMod.mixinConfig().getOptions().get("mixin.fog").isEnabled())
                             .setName(Component.translatable("sodium-extra.option.fog_type.render_distance_start", fogTypeName(fogType)))
                             .setTooltip(Component.translatable("sodium-extra.option.fog_type.render_distance_start.tooltip"))
@@ -356,7 +356,7 @@ public class SodiumExtraConfig implements ConfigEntryPoint {
                             .setValueFormatter(ControlValueFormatterImpls.percentage());
 
                     // Render End
-                    IntegerOptionBuilder renderEnd = builder.createIntegerOption(id(fogType.name().toLowerCase() + "_render_distance_end"))
+                    IntegerOptionBuilder renderEnd = builder.createIntegerOption(id(fogType.name().toLowerCase(Locale.ROOT) + "_render_distance_end"))
                             .setEnabled(SodiumExtraClientMod.mixinConfig().getOptions().get("mixin.fog").isEnabled())
                             .setName(Component.translatable("sodium-extra.option.fog_type.render_distance_end", fogTypeName(fogType)))
                             .setTooltip(Component.translatable("sodium-extra.option.fog_type.render_distance_end.tooltip"))
@@ -371,7 +371,7 @@ public class SodiumExtraConfig implements ConfigEntryPoint {
                             .setValueFormatter(ControlValueFormatterImpls.percentage());
 
                     // Sky End
-                    IntegerOptionBuilder skyEnd = builder.createIntegerOption(id(fogType.name().toLowerCase() + "_sky_end"))
+                    IntegerOptionBuilder skyEnd = builder.createIntegerOption(id(fogType.name().toLowerCase(Locale.ROOT) + "_sky_end"))
                             .setEnabled(SodiumExtraClientMod.mixinConfig().getOptions().get("mixin.fog").isEnabled())
                             .setName(Component.translatable("sodium-extra.option.fog_type.sky_end", fogTypeName(fogType)))
                             .setTooltip(Component.translatable("sodium-extra.option.fog_type.sky_end.tooltip"))
@@ -386,7 +386,7 @@ public class SodiumExtraConfig implements ConfigEntryPoint {
                             .setValueFormatter(ControlValueFormatterImpls.percentage());
 
 
-                    IntegerOptionBuilder cloudEnd = builder.createIntegerOption(id(fogType.name().toLowerCase() + "_cloud_end"))
+                    IntegerOptionBuilder cloudEnd = builder.createIntegerOption(id(fogType.name().toLowerCase(Locale.ROOT) + "_cloud_end"))
                             .setEnabled(SodiumExtraClientMod.mixinConfig().getOptions().get("mixin.fog").isEnabled())
                             .setName(Component.translatable("sodium-extra.option.fog_type.cloud_end", fogTypeName(fogType)))
                             .setTooltip(Component.translatable("sodium-extra.option.fog_type.cloud_end.tooltip"))
@@ -402,7 +402,7 @@ public class SodiumExtraConfig implements ConfigEntryPoint {
 
                     // Add group
                     fogGroups.add(builder.createOptionGroup()
-                            .addOption(builder.createBooleanOption(id(fogType.name().toLowerCase() + "_fog"))
+                            .addOption(builder.createBooleanOption(id(fogType.name().toLowerCase(Locale.ROOT) + "_fog"))
                                     .setEnabled(SodiumExtraClientMod.mixinConfig().getOptions().get("mixin.fog").isEnabled())
                                     .setName(fogTypeName(fogType))
                                     .setTooltip(fogTypeTooltip(fogType))


### PR DESCRIPTION
Fixes crash on systems using Turkish locale.

String identifiers were generated using String#toLowerCase(), which is locale-sensitive and caused invalid characters (I → ı). This change uses Locale.ROOT to ensure consistent behavior.